### PR TITLE
Fix typo and avoid loading it twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -580,6 +580,7 @@ async function getCommentsForVideo(videoUrl) {
         resolve(null);
       }
       else if (comments) {
+        clearInterval(intervalId);
         resolve(comments);
       }
     }, 200);

--- a/index.js
+++ b/index.js
@@ -571,26 +571,28 @@ function timestampToRelativeTime(timestamp) {
   }
 }
 
-function waitForComments() {
-  if (window.location.href !== url && window.location.href.match(/(v=|shorts\/)[a-zA-Z0-9\-_]{11}/)) {
-    const promise = new Promise(resolve => {
-      const intervalId = setInterval(() => {
-        if (document.getElementById("comments")) {
-          clearInterval(intervalId);
-          resolve();
-        }
-      }, 200);
-    });
-    promise.then(update());
-  }
+async function getCommentsForVideo(videoUrl) {
+  return document.getElementById("comments") || new Promise(resolve => {
+    const intervalId = setInterval(() => {
+      const comments = document.getElementById("comments");
+      if(videoUrl !== window.location.href){
+        clearInterval(intervalId);
+        resolve(null);
+      }
+      else if (comments) {
+        resolve(comments);
+      }
+    }, 200);
+  });
 }
 
-function update() {
-  let comments = document.getElementById("comments");
-  if (!comments) {
-    waitForComments();
-  } else {
-    url = window.location.href;
+async function update() {
+  if (window.location.href === url || !window.location.href.match(/(v=|shorts\/)[a-zA-Z0-9\-_]{11}/)) {
+    return;
+  }
+  url = window.location.href;
+  const comments = await getCommentsForVideo(url)
+  if (comments) {
     if (rcfyContainer = document.getElementById("rcfy-container")) {
       rcfyContainer.remove();
     }
@@ -617,6 +619,6 @@ function update() {
   }
 };
 
-document.addEventListener("DOMContentLoaded", () => waitForComments());
-document.addEventListener("yt-navigate-finish", () => waitForComments());
-document.addEventListener("spfdone", () => waitForComments());
+document.addEventListener("DOMContentLoaded", () => update());
+document.addEventListener("yt-navigate-finish", () => update());
+document.addEventListener("spfdone", () => update());


### PR DESCRIPTION
### - Fix a typo on `waitForComments` 
There was a typo that when the comments weren't loaded on update, while on playlists or just old computers, it would throw a stack trace error
 
https://github.com/tayloroneill/Reddit-Comments-for-YouTube/blob/master/index.js#L584
```js
promise.then(update());
````
should be
```js
promise.then(update);
```


### - Improve flow to avoid loading more than once
Sometimes on playlists and watch later it would change the "ìndex" query string before the comments DOM element load and so it would end up creating the `rcfy-thread-selector` twice